### PR TITLE
Dockerfile cleanup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM node:0.10
+FROM node:0.10-slim
 
 ENV APP_DIR /usr/src/koop/
 
 RUN apt-get update \
-	&& apt-get install -y gdal-bin \
-  && apt-get install -y postgresql-client-9.4 \
+  && apt-get install -y gdal-bin postgresql-client-9.4 \
+    --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
   && mkdir -p $APP_DIR
 
 WORKDIR $APP_DIR


### PR DESCRIPTION
Switched to using the nodejs slim image to help reduce the image size.
Small cleanup on package installs.

With these changes we reduce the Docker image size roughly by 498 MB.